### PR TITLE
Charge Bow Tweaks

### DIFF
--- a/SkillsReturnsPlugin/SkillSetup/Huntress/HuntressChargePrimary.cs
+++ b/SkillsReturnsPlugin/SkillSetup/Huntress/HuntressChargePrimary.cs
@@ -30,7 +30,7 @@ namespace SkillsReturns.SkillSetup.Huntress
             skillDef.baseRechargeInterval = 0f;
             skillDef.beginSkillCooldownOnSkillEnd = false;
             skillDef.canceledFromSprinting = false;
-            skillDef.cancelSprintingOnActivation = true;
+            skillDef.cancelSprintingOnActivation = false;
             skillDef.fullRestockOnAssign = true;
             skillDef.interruptPriority = InterruptPriority.Skill;
             skillDef.isCombatSkill = true;
@@ -39,9 +39,10 @@ namespace SkillsReturns.SkillSetup.Huntress
             skillDef.requiredStock = 1;
             skillDef.stockToConsume = 0;
             skillDef.icon = Assets.mainAssetBundle.LoadAsset<Sprite>("PierceIcon");
+            skillDef.keywordTokens = ["KEYWORD_AGILE"];
 
             LanguageAPI.Add(SkillLangTokenName, "Pierce");
-            LanguageAPI.Add(SkillLangTokenDesc, "Charge up a <style=cIsDamage>Piercing</style> arrow for <style=cIsDamage>200%-900%</style> damage.");
+            LanguageAPI.Add(SkillLangTokenDesc, "<style=cIsUtility>Agile</style>. Charge up a <style=cIsDamage>piercing</style> arrow for <style=cIsDamage>200%-800%</style> damage.");
         }
         protected override void CreateAssets()
         {
@@ -51,9 +52,13 @@ namespace SkillsReturns.SkillSetup.Huntress
             ProjectileController pc = chargeArrowProjectilePrefab.GetComponent<ProjectileController>();
             pc.ghostPrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Junk/Huntress/ArrowGhost.prefab").WaitForCompletion();
             pc.allowPrediction = true;
+
             ProjectileOverlapAttack poa = chargeArrowProjectilePrefab.GetComponent<ProjectileOverlapAttack>();
             poa.onServerHit = null;
             poa.impactEffect = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Huntress/OmniImpactVFXHuntress.prefab").WaitForCompletion();
+
+            ProjectileSimple ps = chargeArrowProjectilePrefab.GetComponent<ProjectileSimple>();
+            ps.lifetime = 5f;
            
             R2API.ContentAddition.AddProjectile(chargeArrowProjectilePrefab);
             HuntressChargeArrowFire.ProjectilePrefab = chargeArrowProjectilePrefab;

--- a/SkillsReturnsPlugin/SkillSetup/Huntress/HuntressChargePrimary.cs
+++ b/SkillsReturnsPlugin/SkillSetup/Huntress/HuntressChargePrimary.cs
@@ -46,6 +46,9 @@ namespace SkillsReturns.SkillSetup.Huntress
         }
         protected override void CreateAssets()
         {
+            HuntressChargeArrowFire.soundShoot = Utilities.CreateNetworkSoundEventDef("Play_SkillsReturns_Huntress_ChargeBow_Shoot");
+            HuntressChargeArrowFire.soundShootCharged = Utilities.CreateNetworkSoundEventDef("Play_SkillsReturns_Huntress_ChargeBow_ShootCharged");
+
             GameObject chargeArrowProjectilePrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Commando/FMJRamping.prefab").WaitForCompletion().InstantiateClone("SkillsReturnsHuntressChargeArrowProjectile", true);
             ContentAddition.AddProjectile(chargeArrowProjectilePrefab);
 

--- a/SkillsReturnsPlugin/SkillStates/Huntress/HuntressBowCharge.cs
+++ b/SkillsReturnsPlugin/SkillStates/Huntress/HuntressBowCharge.cs
@@ -41,18 +41,18 @@ namespace SkillsReturns.SkillStates.Huntress
         {
             base.FixedUpdate();
 
+            spread = Mathf.Lerp(1f, 0f, CalculateChargePercent());
+            characterBody.SetSpreadBloom(spread, false);
+
+            if (!playedChargeSound && CalculateChargePercent() >= 1f)
+            {
+                playedChargeSound = true;
+                EffectManager.SimpleMuzzleFlash(ChargeEffectPrefab, gameObject, "Muzzle", false);
+                Util.PlaySound("Play_SkillsReturns_Huntress_ChargeBow_Ready", base.gameObject);
+            }
+
             if (isAuthority)
             {
-
-                if (!playedChargeSound && CalculateChargePercent() >= 1f)
-                {
-                    {
-                        EffectManager.SimpleMuzzleFlash(ChargeEffectPrefab, gameObject, "Muzzle", false);
-                    }
-                    Util.PlaySound("Play_SkillsReturns_Huntress_ChargeBow_Ready", base.gameObject);
-                    playedChargeSound = true;
-                }
-
                 bool shouldExit = base.inputBank && !base.inputBank.skill1.down && base.fixedAge >= minDuration;
                 if (shouldExit)
                 {
@@ -62,8 +62,6 @@ namespace SkillsReturns.SkillStates.Huntress
                     });
                     return;
                 }
-                spread = Mathf.Lerp(1f, 0f, CalculateChargePercent());
-                characterBody.SetSpreadBloom(spread, false);
             }
         }
 

--- a/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
+++ b/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
@@ -20,7 +20,7 @@ namespace SkillsReturns.SkillStates.Huntress
         public float minForce = 500;
         public float maxForce = 2000;   
         public static float minDamageCoefficient = 2f;
-        public static float maxDamageCoefficient = 9f;
+        public static float maxDamageCoefficient = 8f;
         public static GameObject crosshairOverridePrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/UI/StandardCrosshair.prefab").WaitForCompletion();
         private CrosshairUtils.OverrideRequest crosshairOverrideRequest;
         private Animator animator;

--- a/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
+++ b/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
@@ -31,9 +31,6 @@ namespace SkillsReturns.SkillStates.Huntress
             Ray aimRay = GetAimRay();
             StartAimMode(aimRay, 2f, false);
             crosshairOverrideRequest = CrosshairUtils.RequestOverrideForBody(base.characterBody, crosshairOverridePrefab, CrosshairUtils.OverridePriority.Skill);
-            base.PlayAnimation("Gesture, Additive", "FireArrow", "FireArrow.playbackRate", duration * 2);
-            base.PlayAnimation("Gesture, Override", "FireArrow", "FireArrow.playbackRate", duration * 2);
-
 
             if (chargeFraction >= 1f)
             {
@@ -47,9 +44,7 @@ namespace SkillsReturns.SkillStates.Huntress
 
             if (isAuthority)
             {
-                
-                Vector3 aimDirection = aimRay.direction;
-                ProjectileManager.instance.FireProjectile(ProjectilePrefab, aimRay.origin, Util.QuaternionSafeLookRotation(aimDirection), gameObject,
+                ProjectileManager.instance.FireProjectile(ProjectilePrefab, aimRay.origin, Util.QuaternionSafeLookRotation(aimRay.direction), gameObject,
                 damageStat * Mathf.Lerp(minDamageCoefficient, maxDamageCoefficient, chargeFraction), Mathf.Lerp(minForce, maxForce, chargeFraction), base.RollCrit(), DamageColorIndex.Default, null, 180f, DamageTypeCombo.GenericPrimary);
             }
 

--- a/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
+++ b/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
@@ -50,7 +50,7 @@ namespace SkillsReturns.SkillStates.Huntress
                 
                 Vector3 aimDirection = aimRay.direction;
                 ProjectileManager.instance.FireProjectile(ProjectilePrefab, aimRay.origin, Util.QuaternionSafeLookRotation(aimDirection), gameObject,
-                damageStat * Mathf.Lerp(minDamageCoefficient, maxDamageCoefficient, chargeFraction), Mathf.Lerp(minForce, maxForce, chargeFraction), base.RollCrit(), DamageColorIndex.Default, null, 180f);
+                damageStat * Mathf.Lerp(minDamageCoefficient, maxDamageCoefficient, chargeFraction), Mathf.Lerp(minForce, maxForce, chargeFraction), base.RollCrit(), DamageColorIndex.Default, null, 180f, DamageTypeCombo.GenericPrimary);
             }
 
             

--- a/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
+++ b/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
@@ -23,6 +23,7 @@ namespace SkillsReturns.SkillStates.Huntress
         public static float maxDamageCoefficient = 9f;
         public static GameObject crosshairOverridePrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/UI/StandardCrosshair.prefab").WaitForCompletion();
         private CrosshairUtils.OverrideRequest crosshairOverrideRequest;
+        private Animator animator;
 
         public override void OnEnter()
         {
@@ -48,10 +49,11 @@ namespace SkillsReturns.SkillStates.Huntress
                 damageStat * Mathf.Lerp(minDamageCoefficient, maxDamageCoefficient, chargeFraction), Mathf.Lerp(minForce, maxForce, chargeFraction), base.RollCrit(), DamageColorIndex.Default, null, 180f, DamageTypeCombo.GenericPrimary);
             }
 
-            
+            base.PlayCrossfade("Gesture, Override", "FireSeekingShot", "FireSeekingShot.playbackRate", duration * 0.8f, duration * 0.2f/this.attackSpeedStat);
+            base.PlayCrossfade("Gesture, Additive", "FireSeekingShot", "FireSeekingShot.playbackRate", duration * 0.8f, duration * 0.2f/this.attackSpeedStat);
         }
 
-         public override void FixedUpdate()
+        public override void FixedUpdate()
         {
             base.FixedUpdate();
             if (fixedAge >= duration && isAuthority)

--- a/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
+++ b/SkillsReturnsPlugin/SkillStates/Huntress/HuntressChargeArrowFire.cs
@@ -22,6 +22,10 @@ namespace SkillsReturns.SkillStates.Huntress
         public static float minDamageCoefficient = 2f;
         public static float maxDamageCoefficient = 8f;
         public static GameObject crosshairOverridePrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/UI/StandardCrosshair.prefab").WaitForCompletion();
+
+        public static NetworkSoundEventDef soundShoot;
+        public static NetworkSoundEventDef soundShootCharged;
+
         private CrosshairUtils.OverrideRequest crosshairOverrideRequest;
         private Animator animator;
 
@@ -33,20 +37,19 @@ namespace SkillsReturns.SkillStates.Huntress
             StartAimMode(aimRay, 2f, false);
             crosshairOverrideRequest = CrosshairUtils.RequestOverrideForBody(base.characterBody, crosshairOverridePrefab, CrosshairUtils.OverridePriority.Skill);
 
-            if (chargeFraction >= 1f)
-            {
-                Util.PlaySound("Play_SkillsReturns_Huntress_ChargeBow_ShootCharged", base.gameObject);
-               
-            }
-            else
-            {
-                Util.PlaySound("Play_SkillsReturns_Huntress_ChargeBow_Shoot", base.gameObject);
-            }
-
             if (isAuthority)
             {
                 ProjectileManager.instance.FireProjectile(ProjectilePrefab, aimRay.origin, Util.QuaternionSafeLookRotation(aimRay.direction), gameObject,
                 damageStat * Mathf.Lerp(minDamageCoefficient, maxDamageCoefficient, chargeFraction), Mathf.Lerp(minForce, maxForce, chargeFraction), base.RollCrit(), DamageColorIndex.Default, null, 180f, DamageTypeCombo.GenericPrimary);
+
+                if (chargeFraction >= 1f)
+                {
+                    if (soundShootCharged) EffectManager.SimpleSoundEffect(soundShootCharged.index, base.transform.position, true);
+                }
+                else
+                {
+                    if (soundShoot) EffectManager.SimpleSoundEffect(soundShoot.index, base.transform.position, true);
+                }
             }
 
             base.PlayCrossfade("Gesture, Override", "FireSeekingShot", "FireSeekingShot.playbackRate", duration * 0.8f, duration * 0.2f/this.attackSpeedStat);


### PR DESCRIPTION
- Added anims. (slightly scuffed)
- Fixed character not rotating towards crosshair while charging.
- Fixed full charge sound only playing clientside.

- Reduced max charge damage from 900% to 800%. It's still a very strong skill because it can pierce and proc bands.
- Made agile, since re-hitting the sprint key after every single shot felt cancer.